### PR TITLE
revert base image to fix prow build.

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,6 +1,6 @@
 # Copyright (c) 2021 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project.
-FROM registry.ci.openshift.org/open-cluster-management/builder:go1.15-linux AS builder
+FROM registry.ci.openshift.org/open-cluster-management/builder:go1.15-linux-amd64 AS builder
 
 WORKDIR /workspace
 COPY . .


### PR DESCRIPTION
fix prow build:

```
INFO[2021-04-09T07:14:02Z] ci-operator version v20210408-34d4be8        
INFO[2021-04-09T07:14:02Z] Loading configuration from https://config.ci.openshift.org for open-cluster-management/endpoint-metrics-operator@main 
INFO[2021-04-09T07:14:03Z] Resolved source https://github.com/open-cluster-management/endpoint-metrics-operator to main@36a5018c 
INFO[2021-04-09T07:14:03Z] Ran for 0s                                   
ERRO[2021-04-09T07:14:03Z] Some steps failed:                           
ERRO[2021-04-09T07:14:03Z]   * could not resolve inputs: could not determine inputs for step [input:open-cluster-management_builder_go1.15-linux]: could not resolve base image: imagestreamtags.image.openshift.io "builder:go1.15-linux" not found 
```